### PR TITLE
Added keyboard support.

### DIFF
--- a/calculator.html
+++ b/calculator.html
@@ -122,6 +122,17 @@
         }
         
         //Keyboard support
+        function deleteLastDigit() {
+            if (resetDisplay) return; // Don't delete if we just displayed a result or operator
+            
+            if (currentValue.length === 1) {
+                currentValue = '0';
+            } else {
+                currentValue = currentValue.slice(0, -1);
+            }
+            updateDisplay();
+        }
+
         document.addEventListener('keydown', function(event) {
             const key = event.key;
             
@@ -135,6 +146,10 @@
                 clearDisplay();
             } else if (key === '.') {
                 appendNumber('.');
+            } else if (key === 'Backspace') {
+                deleteLastDigit();
+            } else if (key === 'Delete') {
+                clearDisplay();
             }
         });
     </script>

--- a/calculator.html
+++ b/calculator.html
@@ -120,6 +120,23 @@
             resetDisplay = true;
             updateDisplay();
         }
+        
+        //Keyboard support
+        document.addEventListener('keydown', function(event) {
+            const key = event.key;
+            
+            if (/[0-9]/.test(key)) {
+                appendNumber(key);
+            } else if (key === '+' || key === '-' || key === '*' || key === '/') {
+                appendOperator(key);
+            } else if (key === 'Enter' || key === '=') {
+                calculate();
+            } else if (key === 'Escape' || key.toLowerCase() === 'c') {
+                clearDisplay();
+            } else if (key === '.') {
+                appendNumber('.');
+            }
+        });
     </script>
 </body>
 </html>


### PR DESCRIPTION
Added keyboard support to the calculator so it can be used without mouse clicks.

**What Was Fixed:**

The calculator now responds to keyboard input, matching the behavior of button clicks.
Supported Keys
Number keys (0–9)
Operators (+, -, *, /)
Enter or = for calculation
Escape or C to clear
Decimal point (.)

**Result:**

Users can fully operate the calculator using the keyboard.