### PR TITLE
Fix calculator equals behavior when second operand is missing

### DIFF
--- a/calculator.html
+++ b/calculator.html
@@ -106,11 +106,62 @@
             try {
                 if (!expression) return;
                 
-                // Clean trailing operators before calculating
+                // Prepare expression for calculating
                 let evalExpr = expression;
                 const operators = ['+', '-', '*', '/'];
-                while (operators.includes(evalExpr.slice(-1))) {
-                    evalExpr = evalExpr.slice(0, -1);
+
+                // If expression ends with an operator, duplicate the last entered number
+                // Example: "5-" -> use "5-5"; "12+3-" -> use "12+3-3"
+                const lastChar = expression.slice(-1);
+                if (operators.includes(lastChar)) {
+                    // Find the last operator position that is not a unary minus
+                    let lastOpIndex = -1;
+                    for (let i = expression.length - 1; i >= 0; i--) {
+                        const ch = expression[i];
+                        if (operators.includes(ch)) {
+                            if (ch === '-' && (i === 0 || operators.includes(expression[i - 1]))) {
+                                // unary minus, skip
+                                continue;
+                            }
+                            lastOpIndex = i;
+                            break;
+                        }
+                    }
+
+                    if (lastOpIndex !== -1) {
+                        const leftExpr = expression.slice(0, lastOpIndex);
+                        const op = expression[lastOpIndex];
+
+                        // Extract the last number from leftExpr (handles negative numbers)
+                        const numMatch = leftExpr.match(/(-?\d+(?:\.\d+)?)$/);
+                        let lastNumber = '0';
+                        if (numMatch) {
+                            lastNumber = numMatch[0];
+                            // If leftExpr is just the last number (no preceding expr), preserve it as-is
+                        } else if (leftExpr !== '') {
+                            // Fallback: use whole leftExpr if no number found
+                            lastNumber = leftExpr;
+                        } else {
+                            // Nothing to duplicate; fall back to trimming trailing operators
+                            let tmp = evalExpr;
+                            while (operators.includes(tmp.slice(-1))) tmp = tmp.slice(0, -1);
+                            evalExpr = tmp;
+                        }
+
+                        if (lastNumber !== '') {
+                            evalExpr = leftExpr + op + lastNumber;
+                        }
+                    } else {
+                        // No valid operator found (e.g., expression is just "-"), trim trailing operators
+                        while (operators.includes(evalExpr.slice(-1))) {
+                            evalExpr = evalExpr.slice(0, -1);
+                        }
+                    }
+                } else {
+                    // Regular case: remove any accidental trailing operators
+                    while (operators.includes(evalExpr.slice(-1))) {
+                        evalExpr = evalExpr.slice(0, -1);
+                    }
                 }
 
                 // Safe evaluation

--- a/calculator.html
+++ b/calculator.html
@@ -59,7 +59,6 @@
         }
 
         function appendNumber(num) {
-            // Prevent multiple decimals in the same number segment
             if (num === '.') {
                 const operators = ['+', '-', '*', '/'];
                 const parts = expression.split(/[\+\-\*\/]/);
@@ -78,7 +77,6 @@
         function appendOperator(op) {
             const operators = ['+', '-', '*', '/'];
             
-            // Allow negative sign at start
             if (expression === '' && op === '-') {
                 expression += op;
                 updateDisplay();
@@ -93,7 +91,7 @@
                 if (op === '-' && lastChar !== '-') {
                     expression += op;
                 } else {
-                    // Replace the operator
+               
                     expression = expression.slice(0, -1) + op;
                 }
             } else {
@@ -102,76 +100,75 @@
             updateDisplay();
         }
 
+        function trimTrailingOperators(str) {
+            const ops = ['+', '-', '*', '/'];
+            let s = str;
+            while (s.length && ops.includes(s.slice(-1))) {
+                s = s.slice(0, -1);
+            }
+            return s;
+        }
+
+        function findLastOperatorIndex(expr) {
+            const ops = ['+', '-', '*', '/'];
+            for (let i = expr.length - 1; i >= 0; i--) {
+                const currentChar = expr[i];
+                if (ops.includes(currentChar)) {
+                    if (currentChar === '-' && (i === 0 || ops.includes(expr[i - 1]))) {
+                        continue;
+                    }
+                    return i;
+                }
+            }
+            return -1;
+        }
+
+        function extractLastNumber(str) {
+            const match = str.match(/(-?\d+(?:\.\d+)?)$/);
+            return match ? match[0] : '';
+        }
+
+        function handleTrailingOperator(expr) {
+            const lastOpIndex = findLastOperatorIndex(expr);
+            if (lastOpIndex === -1) return trimTrailingOperators(expr);
+
+            const leftExpr = expr.slice(0, lastOpIndex);
+            const op = expr[lastOpIndex];
+
+            if (leftExpr === '') return trimTrailingOperators(expr);
+
+            const lastNumber = extractLastNumber(leftExpr) || leftExpr;
+            if (lastNumber !== '') {
+                return leftExpr + op + lastNumber;
+            }
+
+            return trimTrailingOperators(expr);
+        }
+
         function calculate() {
             try {
                 if (!expression) return;
                 
-                // Prepare expression for calculating
+                
                 let evalExpr = expression;
                 const operators = ['+', '-', '*', '/'];
 
-                // If expression ends with an operator, duplicate the last entered number
-                // Example: "5-" -> use "5-5"; "12+3-" -> use "12+3-3"
+              
                 const lastChar = expression.slice(-1);
                 if (operators.includes(lastChar)) {
-                    // Find the last operator position that is not a unary minus
-                    let lastOpIndex = -1;
-                    for (let i = expression.length - 1; i >= 0; i--) {
-                        const ch = expression[i];
-                        if (operators.includes(ch)) {
-                            if (ch === '-' && (i === 0 || operators.includes(expression[i - 1]))) {
-                                // unary minus, skip
-                                continue;
-                            }
-                            lastOpIndex = i;
-                            break;
-                        }
-                    }
-
-                    if (lastOpIndex !== -1) {
-                        const leftExpr = expression.slice(0, lastOpIndex);
-                        const op = expression[lastOpIndex];
-
-                        // Extract the last number from leftExpr (handles negative numbers)
-                        const numMatch = leftExpr.match(/(-?\d+(?:\.\d+)?)$/);
-                        let lastNumber = '0';
-                        if (numMatch) {
-                            lastNumber = numMatch[0];
-                            // If leftExpr is just the last number (no preceding expr), preserve it as-is
-                        } else if (leftExpr !== '') {
-                            // Fallback: use whole leftExpr if no number found
-                            lastNumber = leftExpr;
-                        } else {
-                            // Nothing to duplicate; fall back to trimming trailing operators
-                            let tmp = evalExpr;
-                            while (operators.includes(tmp.slice(-1))) tmp = tmp.slice(0, -1);
-                            evalExpr = tmp;
-                        }
-
-                        if (lastNumber !== '') {
-                            evalExpr = leftExpr + op + lastNumber;
-                        }
-                    } else {
-                        // No valid operator found (e.g., expression is just "-"), trim trailing operators
-                        while (operators.includes(evalExpr.slice(-1))) {
-                            evalExpr = evalExpr.slice(0, -1);
-                        }
-                    }
+                    evalExpr = handleTrailingOperator(expression);
                 } else {
-                    // Regular case: remove any accidental trailing operators
-                    while (operators.includes(evalExpr.slice(-1))) {
-                        evalExpr = evalExpr.slice(0, -1);
-                    }
+                    evalExpr = trimTrailingOperators(evalExpr);
                 }
 
-                // Safe evaluation
+              
                 let result = new Function('return ' + evalExpr)();
                 
                 if (!isFinite(result)) {
                     display.classList.add('error');
                     expression = 'Cannot divide by zero!';
                     updateDisplay();
-                    // Reset after a delay or next click
+                   
                     setTimeout(() => { 
                         expression = ''; 
                         display.classList.remove('error');
@@ -180,10 +177,10 @@
                     return;
                 }
 
-                // Add to history
+                
                 addToHistory(evalExpr, result);
 
-                // Update expression to result for next calculation
+                
                 expression = result.toString();
                 updateDisplay();
 
@@ -193,7 +190,7 @@
             }
         }
         
-        // Keyboard support (Merged from Main Branch)
+        
         function deleteLastChar() {
             expression = expression.slice(0, -1);
             updateDisplay();
@@ -207,7 +204,7 @@
             } else if (key === '+' || key === '-' || key === '*' || key === '/') {
                 appendOperator(key);
             } else if (key === 'Enter' || key === '=') {
-                event.preventDefault(); // Prevent accidental form submissions
+                event.preventDefault();
                 calculate();
             } else if (key === 'Escape' || key.toLowerCase() === 'c') {
                 clearDisplay();


### PR DESCRIPTION
Problem

When the equals (=) button is pressed immediately after selecting an operator (without entering a second number), the calculator returns 0.
This behavior is confusing and does not align with expected calculator behavior.

Expected Behavior

The calculator should handle this scenario more gracefully by one of the following:
Using the first number as the second operand (e.g., 5 - 5 = 0)
Displaying the current value
Showing a clear error or validation message

Solution

Updated the equals (=) handling logic to properly manage cases where the second operand is missing.
Prevents unintended defaulting to 0.